### PR TITLE
feat: add blog post comparing ASDF and Nix development environments

### DIFF
--- a/content/posts/2026/asdf c est cool nix c est mieux/index.en.md
+++ b/content/posts/2026/asdf c est cool nix c est mieux/index.en.md
@@ -1,0 +1,246 @@
+---
+title: "ASDF is cool, but Nix is better"
+date: "2026-05-27T21:18:18+02:00"
+tags:
+- asdf
+- nix
+- tools
+- devops
+categories:
+- tips
+- tools
+description: >-
+  "Discover how to use ASDF to easily manage different development tool versions and simplify your workflow."
+---
+
+After testing [ASDF](/en/tags/asdf/) for some time,
+I decided to switch to [Nix](/en/tags/nix/).
+Here is why.
+
+I believe in the GitOps principle: everything needed for a project to run
+smoothly must be versioned and easily replicable. For this,
+[ASDF](/en/tags/asdf/) is not bad at all, but it still has a few flaws.
+
+## The flaws of ASDF
+
+With [ASDF](/en/tags/asdf/), we have `~/.tool-versions` which allows us
+to specify which version to use. And that's cool.
+
+But (and there is a "but"). Often, I used `~/.tool-versions` to define
+the global version I was using. I even set up a renovate rule for it:
+[renovate.json5](https://github.com/julien-noblet/dotfiles/blob/master/renovate.json5)
+
+So every time, my environment is more or less up to date...
+
+Including my dev tools!
+
+I could have continued using a `.tool-versions` file for my projects
+to avoid breaking my local tests. Yes.
+
+Another issue was bothering me: how to ensure I have the exact same version...
+And especially if I change machines,
+how to be sure I have the exact same tools?
+
+(Yes, node20 can be node 20.0, 20.1, 20.2...)
+
+Another annoying thing: how to install custom tools?
+
+With [ASDF](/en/tags/asdf/), you have to create a new plugin, push it,
+add it to your configuration...
+A nightmare!
+
+And then there were times when I had to fight with `asdf reshim`.
+
+Last point (which is somewhat related to the previous one),
+I needed more and more custom plugins made by third parties.
+How to make sure one of the plugins doesn't contain malicious code?
+
+Especially with a plugin used by few people, the risk is higher.
+And I don't have time to audit every repo! (Who does?)
+
+## Mise (en place)
+
+Pronounced /meez ahn plahs/
+
+There is [mise](https://mise.jdx.dev/) which can secure this,
+and it also allows managing programs via registries like [aqua](https://aquaproj.org/)
+
+The workflow is almost the same as [ASDF](/en/tags/asdf/), but it is faster
+(there are no shims, it cleverly adjusts your `$PATH`)
+
+It also allows hooks and plenty of nice features.
+
+I will probably write about it again since I am trying to push this solution
+at work.
+
+## Yes, but security is not quite there yet
+
+Yes, because whether it's with [ASDF](/en/tags/asdf/) or Mise,
+programs are installed in a folder to which the current user has access.
+
+In a flash, I can break a program, and fixing it is never easy.
+
+## OK, just don't play around with ~/.local and it should be fine, right?
+
+Yes.
+
+In most cases.
+
+But I ran into some obscure cases, especially with annoying programs
+using old glibc versions or similar.
+And making two different `.so` files cohabitate is never simple.
+
+## Well OK... What about [Nix](/en/tags/nix/) in all this?
+
+[Nix](/en/tags/nix/) is a package manager, but above all, it's a language.
+
+It allows you to define environments declaratively,
+with well-defined dependencies.
+
+It saves everything in its store.
+A directory that appears as immutable.
+This way, it's impossible to break a program by modifying a file.
+
+[Nix](/en/tags/nix/) is pretty cool, but in my opinion, it really shines with Flakes.
+
+Flakes adds an abstraction layer and also pins versions.
+(A bit like `go.sum` or `package-lock.json` but for everything!)
+
+Here is an example of a `flake.nix` used for this site:
+
+```nix
+{
+  description = "Julien Noblet's blog development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      allSystems = [
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "aarch64-darwin" # 64-bit ARM macOS
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+    in
+    {
+      devShells = forAllSystems ({ pkgs }: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            hugo
+            nodejs
+            git
+            gnumake
+          ];
+
+          shellHook = ''
+            echo "--------------------------------------------------"
+            echo " Welcome to the blog development environment!     "
+            echo " Hugo: $(hugo version | cut -d' ' -f2)"
+            echo " Node: $(node --version)"
+            echo " Git:  $(git --version | cut -d' ' -f3)"
+            echo " Make: $(make --version | head -n1)"
+            echo "--------------------------------------------------"
+
+            # Automatically initialize Git submodules if they are missing
+            if [ -d .git ] && [ ! -f "themes/PaperMod/theme.toml" ]; then
+              echo "Initializing Git submodules..."
+              git submodule update --init --recursive
+            fi
+          '';
+        };
+      });
+    };
+}
+```
+
+## What does it say?
+
+We define our inputs here, and in our case, we "just" use the nixpkgs repo.
+
+Then, we define the list of programs and the commands to run when opening
+the shell.
+
+Here, we add a small hook to initialize Git submodules if they are not already.
+
+Note that the `allSystems` part defines the systems for which we want to
+build our shell. And `forAllSystems` is just a helper function to avoid
+repeating code.
+
+Thanks to this, I make sure the current version will be pinned for Linux, Mac...
+
+In this file, there is really everything you need to compile, test, and
+push the site!
+
+The only thing I didn't add is the text editor.
+
+## OK, but I don't see the versions
+
+That's true!
+
+How do I know I am using `hugo v0.161.1`, `Node.js v24.15.0`,
+`git version 2.54.0` and `GNU Make 4.4.1`?
+
+It's all in `flake.lock`:
+
+```json
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}
+```
+
+Here, we can see that I must retrieve the version known by `nixpkgs` at commit `64c08a7ca051951c8eae34e3e3cb1e202fe36786`.
+
+I don't really need to know which version I have.
+I just need to know that it works on my machine, so it will work elsewhere.
+
+## What about the build?
+
+The build will also use [Nix](/en/tags/nix/), and with the exact same
+versions to the byte!
+Modulo the OS and CPU architecture (the `allSystems`), but in this case,
+they will use the exact same original source code to compile the programs!
+
+And this is true whether I am on Ubuntu, Debian, NixOS, Suse, Fedora...
+
+## NixOS?
+
+NixOS is a Linux distribution based on [Nix](/en/tags/nix/).
+It uses [Nix](/en/tags/nix/) to manage packages and configurations.
+
+So here, we no longer configure just dev tools, but the entire system.
+From the kernel to the graphics card configuration, disks, and system tools...
+
+This pushes GitOps to its absolute limit!
+I can even generate ready-to-use images for my Raspberry Pi.
+
+In short, [ASDF](/en/tags/asdf/) was cool, but [Nix](/en/tags/nix/) is
+really better 😉!

--- a/content/posts/2026/asdf c est cool nix c est mieux/index.fr.md
+++ b/content/posts/2026/asdf c est cool nix c est mieux/index.fr.md
@@ -1,0 +1,253 @@
+---
+title: "ASDF, c'est cool mais Nix, c'est mieux"
+date: "2026-05-27T21:18:18+02:00"
+tags:
+- asdf
+- nix
+- tools
+- devops
+categories:
+- tips
+- tools
+description: >-
+  "Découvrez comment utiliser asdf pour gérer facilement différentes versions
+  d'outils de développement et simplifier votre workflow."
+---
+
+Après avoir testé [asdf](/tags/asdf/) pendant quelque temps,
+j'ai décidé de passer à [Nix](/tags/nix/).
+Voici pourquoi.
+
+Je crois au **principe** GitOps, à savoir que tout ce qui est nécessaire au bon
+fonctionnement d'un projet doit être versionné et facilement réplicable.
+Pour cela, [ASDF](/tags/asdf/) n'est pas mal du tout, mais il présente tout de
+même quelques défauts.
+
+## Les défauts d'ASDF
+
+Avec [ASDF](/tags/asdf/), on a le `~/.tool-versions` qui nous permet de dire
+quelle version utiliser. Et c'est cool.
+
+Mais (et il y en a). Souvent, j'utilisais le `~/.tool-versions` pour définir
+la version globale que j'utilisais. J'ai même fait une règle renovate pour
+cela : [renovate.json5](https://github.com/julien-noblet/dotfiles/blob/master/renovate.json5)
+
+Donc à chaque fois, j'ai mon environnement +/- à jour...
+
+Dont mes outils de dev !
+
+J'aurais pu continuer avec un `.tool-versions` pour mes projets afin de ne pas
+casser mes tests en local. Oui.
+
+Un autre souci me tracassait : comment m'assurer d'avoir exactement la même version...
+Et surtout, si je change de poste,
+comment être sûr d'avoir exactement les mêmes outils ?
+
+(Oui node20, ça peut être node 20.0, 20.1, 20.2...)
+
+Un autre truc relou : comment installer des outils customs ?
+
+Avec [ASDF](/tags/asdf/), il faut faire un nouveau plugin, le pousser,
+l'ajouter dans sa configuration...
+Un enfer!
+
+Et puis j'ai eu des fois où j'ai dû me battre avec `asdf reshim`.
+
+Dernier point (qui est un peu lié au précédent),
+j'ai eu besoin de plus en plus de plugins customs faits par des tiers.
+Comment m'assurer que l'un des plugins n'embarque pas de code malicieux ?
+
+Surtout avec un plugin utilisé par peu de monde, le risque est plus élevé.
+Et je n'ai pas le temps d'auditer tous les repos ! (Qui l'a ?)
+
+## Mise (en place)
+
+Il y a [mise](https://mise.jdx.dev/) qui peut sécuriser cela,
+en plus il permet de gérer aussi des programmes via des registries comme [aqua](https://aquaproj.org/)
+
+Le workflow est quasi le même que [ASDF](/tags/asdf/), mais c'est plus rapide
+(on n'a pas de shim, il ajuste astucieusement votre `$PATH`)
+
+Il permet aussi de faire des `hooks` et plein de fonctionnalités sympas.
+
+Je reviendrai dessus, je pense, car j'essaie de pousser cette solution au bureau.
+
+## Oui mais la sécurité n'est pas encore là
+
+Oui, car que ce soit avec [ASDF](/tags/asdf/) ou Mise,
+les programmes sont installés dans un dossier auquel l'utilisateur courant a accès.
+
+En un éclair, je peux casser un programme et pour le remettre, ce n'est jamais simple.
+
+## OK, il suffit de ne pas jouer avec le `~/.local` et ça passe, non ?
+
+Oui.
+
+Dans la plupart des cas.
+
+Mais je suis tombé sur quelques cas obscurs, notamment avec des programmes relous
+utilisant de vieilles glibc ou autres.
+Et faire cohabiter deux `.so` différents, ce n'est jamais si simple.
+
+## Bon OK... Et [Nix](/tags/nix/) dans tout ça ?
+
+[Nix](/tags/nix/), c'est un gestionnaire de paquets, mais c'est surtout un langage.
+
+Il permet de définir des environnements de manière déclarative,
+avec des dépendances bien définies.
+
+Il enregistre tout dans son store.
+Un dossier qui apparaît comme immuable.
+Comme ça, il est impossible de casser un programme en modifiant un fichier.
+
+[Nix](/tags/nix/), ce n'est pas mal, mais c'est avec les Flakes que cela prend
+tout son sens selon moi.
+
+Flakes va ajouter une couche d'abstraction et permettre également de figer
+les versions.
+(Un peu comme le `go.sum` ou `package-lock.json` mais pour tout !)
+
+Voici un exemple de `flake.nix` utilisé pour ce site :
+
+```nix
+{
+  description = "Julien Noblet's blog development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      allSystems = [
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "aarch64-darwin" # 64-bit ARM macOS
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+    in
+    {
+      devShells = forAllSystems ({ pkgs }: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            hugo
+            nodejs
+            git
+            gnumake
+          ];
+
+          shellHook = ''
+            echo "--------------------------------------------------"
+            echo " Welcome to the blog development environment!     "
+            echo " Hugo: $(hugo version | cut -d' ' -f2)"
+            echo " Node: $(node --version)"
+            echo " Git:  $(git --version | cut -d' ' -f3)"
+            echo " Make: $(make --version | head -n1)"
+            echo "--------------------------------------------------"
+
+            # Automatically initialize Git submodules if they are missing
+            if [ -d .git ] && [ ! -f "themes/PaperMod/theme.toml" ]; then
+              echo "Initializing Git submodules..."
+              git submodule update --init --recursive
+            fi
+          '';
+        };
+      });
+    };
+}
+```
+
+## Ça dit quoi ?
+
+On définit ici nos entrées, et dans notre cas, on utilise "juste" le repo
+nixpkgs.
+
+Ensuite, on définit la liste des programmes, et les commandes à exécuter lors de
+l'ouverture du shell.
+
+Ici, on ajoute un petit hook pour initialiser les sous-modules Git si ce n'est pas
+déjà fait.
+
+Notez que la partie `allSystems` permet de définir les systèmes pour lesquels on
+veut builder notre shell. Et `forAllSystems` est juste une fonction helper pour
+éviter de répéter du code.
+
+Grâce à cela, je m'assure que la version actuelle sera figée pour Linux, Mac...
+
+Dans ce fichier, il y a vraiment tout ce qu'il faut pour compiler, tester, pousser
+le site !
+
+Il n'y a que l'éditeur de texte que je n'ai pas ajouté.
+
+## OK mais je ne vois pas les versions
+
+C'est vrai !
+
+Comment savoir que je suis avec `hugo v0.161.1`,
+`Node.js v24.15.0`, `git version 2.54.0` et `GNU Make 4.4.1` ?
+
+Tout est dans `flake.lock` :
+
+```json
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}
+```
+
+Ici on peut comprendre que je dois récupérer la version connue par `nixpkgs`,
+sur le commit `64c08a7ca051951c8eae34e3e3cb1e202fe36786`.
+
+Je n'ai pas vraiment besoin de connaître la version que j'ai.
+J'ai simplement besoin de savoir que ça marche sur mon poste,
+donc ça va marcher ailleurs.
+
+## Et le build?
+
+Le build aussi utilisera [Nix](/tags/nix/), et avec les mêmes versions
+à l'octet près !
+Modulo l'OS et l'architecture CPU (les `allSystems`) mais dans ce cas,
+ils utiliseront exactement le même code source d'origine pour
+la compilation des programmes !
+
+Et cela que je sois sous Ubuntu, Debian, NixOS, Suse, Fedora ...
+
+## NixOS ?
+
+NixOS est une distribution Linux basée sur [Nix](/tags/nix/).
+Elle utilise [Nix](/tags/nix/) pour gérer les paquets et les configurations.
+
+Donc on ne charge plus ici que les outils de dev, mais vraiment tout le système.
+Du noyau, en passant par la configuration de la carte graphique, des disques,
+des outils système...
+
+Cela permet de pousser le GitOps à son paroxysme !
+Je peux même générer des images prêtes à l'emploi pour mes Raspberry Pi.
+
+Bref, [ASDF](/tags/asdf/), c'était cool, [Nix](/tags/nix/) c'est vraiment
+mieux 😉 !


### PR DESCRIPTION
This pull request adds a new blog post comparing ASDF and Nix for development environment management, providing both English and French versions. The post discusses the limitations of ASDF, introduces alternative tools like Mise, and highlights the advantages of using Nix and Nix Flakes for reproducible and declarative development environments.

**New Content:**

* Added a comprehensive blog post in English (`index.en.md`) explaining why Nix is superior to ASDF for managing development tools, including practical examples and configuration snippets.
* Added a French translation of the blog post (`index.fr.md`) with equivalent content, covering the same comparison and technical details.

**Key Themes Covered:**

* Comparison of ASDF and Nix for tool version management and reproducibility.
* Discussion of security and maintainability concerns with ASDF plugins.
* Introduction to Mise as an alternative and its workflow.
* Detailed explanation of using Nix Flakes for environment pinning and multi-platform support.
* Practical configuration examples (`flake.nix`, `flake.lock`) and their benefits for development and builds.

These additions enhance the documentation by providing in-depth, multilingual guidance on modern development environment management.